### PR TITLE
Added Build instructions for Ubuntu

### DIFF
--- a/README
+++ b/README
@@ -3,3 +3,11 @@ http://cscapes.cs.purdue.edu/coloringpage/software.htm
 
 ColPack's project home page:
 http://cscapes.cs.purdue.edu/coloringpage/
+
+Ubuntu Build Instructions
+=========================
+In the `ColPack` directory run the following:
+
+    autoreconf -vif
+    ./configure
+    make -j 4   #Where "4" is the number of cores on your machine


### PR DESCRIPTION
Was tricky to figure out how to compile everything. Putting instructions in the GitHub README file should make things easier for everyone.