### PR TITLE
clean up the 114 warnings of compiling the codes

### DIFF
--- a/BipartiteGraphBicoloring/BipartiteGraphBicoloring.cpp
+++ b/BipartiteGraphBicoloring/BipartiteGraphBicoloring.cpp
@@ -1284,7 +1284,7 @@ namespace ColPack
 
 		int i_EdgeID, i_NeighboringEdgeID;
 
-		int i_EdgeCount;
+		//int i_EdgeCount; //unused variable
 
 		int i_LeftVertexCount, i_RightVertexCount;
 
@@ -1301,7 +1301,7 @@ namespace ColPack
 		i_LeftVertexCount  = STEP_DOWN((signed) m_vi_LeftVertices.size());
 		i_RightVertexCount = STEP_DOWN((signed) m_vi_RightVertices.size());
 
-		i_EdgeCount = (signed) m_vi_Edges.size()/2;
+		//i_EdgeCount = (signed) m_vi_Edges.size()/2; //unused variable
 
 		m_mimi2_VertexEdgeMap.clear();
 
@@ -5322,7 +5322,7 @@ namespace ColPack
 
 		output = m_vi_RightVertexColors;
 
-		for (int i=0; i < output.size(); i++) {
+		for (size_t i=0; i < output.size(); i++) {
 			output[i] -= rowCount;
 			if (output[i] == columnCount + 1) output[i] = 0; //color 0, the rows with this color should be ignored.
 		}

--- a/BipartiteGraphBicoloring/BipartiteGraphInputOutput.cpp
+++ b/BipartiteGraphBicoloring/BipartiteGraphInputOutput.cpp
@@ -136,7 +136,7 @@ namespace ColPack
 
 		istringstream in2;
 		int entry_counter = 0, num_of_entries = 0, nz_counter=0;
-		bool value_not_specified = false;
+		//bool value_not_specified = false;
 		int i_LineCount = _TRUE;
 
 		int i, j;
@@ -259,12 +259,12 @@ namespace ColPack
 				in2.clear();
 				in2.str(s_InputLine);
 				d_Value =-999999999.;
-				value_not_specified=false;
+				//value_not_specified=false;
 				in2>>i_LeftVertex>>i_RightVertex>>d_Value;
 				entry_counter++;
 				if(d_Value == -999999999. && in2.eof()) {
 				  // "d_Value" entry is not specified
-				  value_not_specified = true;
+				  //value_not_specified = true;
 				}
 				else if (d_Value == 0) {
 				  continue;
@@ -501,7 +501,8 @@ namespace ColPack
 			cout<<"Found File "<<m_s_InputFile<<endl;
 		}
 
-		int i_Dummy, i, j;
+		//int i_Dummy; //unused variable
+                int i, j;
 		int num;
 		int nnz;
 		string line, num_string;
@@ -595,7 +596,7 @@ namespace ColPack
 		//populate the m_vi_LeftVertices and their edges at the same time
 		m_vi_LeftVertices[0]=0;
 		for(i=0; i<NROW; i++) {
-		  for(j=0; j<vvi_LeftVertexAdjacency[i].size();j++) {
+		  for(j=0; j<(int)vvi_LeftVertexAdjacency[i].size();j++) {
 		    m_vi_Edges[m_vi_LeftVertices[i]+j] = vvi_LeftVertexAdjacency[i][j];
 		  }
 
@@ -605,7 +606,7 @@ namespace ColPack
 		//populate the m_vi_RightVertices and their edges at the same time
 		m_vi_RightVertices[0]=m_vi_LeftVertices[NROW];
 		for(i=0; i<NCOL; i++) {
-		  for(j=0; j<vvi_RightVertexAdjacency[i].size();j++) {
+		  for(j=0; j<(int)vvi_RightVertexAdjacency[i].size();j++) {
 		    m_vi_Edges[m_vi_RightVertices[i]+j] = vvi_RightVertexAdjacency[i][j];
 		  }
 
@@ -937,7 +938,7 @@ namespace ColPack
 	  //PrintBipartiteGraph ();
 	  //Pause();
 	  for(i=0; i < i_RowCount; i++) {
-	    for(j=ip_RowIndex[i]; j<ip_RowIndex[i+1]; j++) {
+	    for(j=ip_RowIndex[i]; j<(size_t)ip_RowIndex[i+1]; j++) {
 	      m_vi_Edges.push_back(ip_ColumnIndex[j]);
 	      colList[ ip_ColumnIndex[j] ].push_back(i);
 	    }
@@ -971,8 +972,8 @@ namespace ColPack
 	}
 
 	int BipartiteGraphInputOutput::BuildBPGraphFromADICFormat(std::list<std::set<int> > *  lsi_SparsityPattern, int i_ColumnCount) {
-	  int i;
-	  unsigned int j;
+	  //int i;  //unused variable
+	  //unsigned int j; //unused variable
 	  map< int,vector<int> > colList;
 	  int i_RowCount = (*lsi_SparsityPattern).size();
 

--- a/BipartiteGraphBicoloring/BipartiteGraphOrdering.cpp
+++ b/BipartiteGraphBicoloring/BipartiteGraphOrdering.cpp
@@ -123,7 +123,7 @@ namespace ColPack
 
 		m_s_VertexOrderingVariant = "RANDOM";
 
-		int i;
+		//int i;  //unused variable
 
 		int i_LeftVertexCount, i_RightVertexCount;
 
@@ -135,7 +135,7 @@ namespace ColPack
 		//Order left vertices
 		m_vi_OrderedVertices.resize((unsigned) i_LeftVertexCount);
 
-		for(unsigned int i = 0; i<i_LeftVertexCount; i++) {
+		for(unsigned int i = 0; i<(unsigned)i_LeftVertexCount; i++) {
 			m_vi_OrderedVertices[i] = i;
 		}
 
@@ -146,7 +146,7 @@ namespace ColPack
 
 		tempOrdering.resize((unsigned) i_RightVertexCount);
 
-		for(unsigned int i = 0; i<i_RightVertexCount; i++) {
+		for(unsigned int i = 0; i<(unsigned)i_RightVertexCount; i++) {
 			tempOrdering[i] = i + i_LeftVertexCount;
 		}
 
@@ -155,7 +155,7 @@ namespace ColPack
 		m_vi_OrderedVertices.reserve(i_LeftVertexCount + i_RightVertexCount);
 
 		//Now, populate vector m_vi_OrderedVertices with the right vertices
-		for(unsigned int i = 0; i<i_RightVertexCount; i++) {
+		for(unsigned int i = 0; i<(unsigned)i_RightVertexCount; i++) {
 			m_vi_OrderedVertices.push_back(tempOrdering[i]);
 		}
 
@@ -257,7 +257,8 @@ namespace ColPack
 			return(_TRUE);
 		}
 
-		int i, u, l, v;
+		int i, u, l;
+                //int v; //unused variable
 
 		int _FOUND;
 
@@ -386,7 +387,7 @@ namespace ColPack
 					}
 					*/
 					if(vi_LeftSidedVertexinBucket[i] > 0)
-					for(int j  = 0; j < vvi_GroupedInducedVertexDegree[i].size(); j++)
+					for(unsigned int j  = 0; j < vvi_GroupedInducedVertexDegree[i].size(); j++)
 					{
 						u = vvi_GroupedInducedVertexDegree[i][j];
 						if(u < i_LeftVertexCount)
@@ -416,7 +417,7 @@ namespace ColPack
 					_FOUND = _FALSE;
 
 					if((i_InducedVertexDegreeCount - vi_LeftSidedVertexinBucket[i]) > 0)
-					for(int j = 0; j < vvi_GroupedInducedVertexDegree[i].size(); j++)
+					for(unsigned int j = 0; j < vvi_GroupedInducedVertexDegree[i].size(); j++)
 					{
 						u = vvi_GroupedInducedVertexDegree[i][j];
 
@@ -580,7 +581,8 @@ namespace ColPack
 
 		int i_VertexDegree;
 
-		int i_IncidenceVertexDegree, i_IncidenceVertexDegreeCount;
+		int i_IncidenceVertexDegree;
+                //int i_IncidenceVertexDegreeCount; //unused variable
 
 		int i_SelectedVertex, i_SelectedVertexCount;
 

--- a/BipartiteGraphPartialColoring/BipartiteGraphPartialColoring.cpp
+++ b/BipartiteGraphPartialColoring/BipartiteGraphPartialColoring.cpp
@@ -290,11 +290,14 @@ namespace ColPack
 			return(_TRUE);
 		}
 
-		int i_LeftVertexCount, i_RightVertexCount, i_CurrentVertex;
+		int i_LeftVertexCount;
+                //int i_CurrentVertex;    //unused variable
+                //int i_RightVertexCount  //unused variable
+
 		bool cont=false;
 		vector<int> vi_forbiddenColors, vi_VerticesToBeColored, vi_verticesNeedNewColor;
 		i_LeftVertexCount = (int) m_vi_LeftVertices.size() - 1;
-		i_RightVertexCount = (int)m_vi_RightVertices.size () - 1;
+		//i_RightVertexCount = (int)m_vi_RightVertices.size () - 1;
 		m_i_LeftVertexColorCount = m_i_RightVertexColorCount = m_i_VertexColorCount = 0;
 
 		// !!! do sections for this part ? forbiddenColors may need to be private for each thread
@@ -403,7 +406,7 @@ namespace ColPack
 			i_NumOfVerticesToBeColored = vi_verticesNeedNewColor.size();
 
 			vi_VerticesToBeColored.reserve(vi_verticesNeedNewColor.size());
-			for(int i=0; i<vi_verticesNeedNewColor.size(); i++) {
+			for(size_t i=0; i<vi_verticesNeedNewColor.size(); i++) {
 			  vi_VerticesToBeColored.push_back(vi_verticesNeedNewColor[i]);
 			}
 
@@ -496,7 +499,8 @@ namespace ColPack
 		  return(_TRUE);
 		}
 
-		int i_LeftVertexCount, i_RightVertexCount, i_CurrentVertex;
+		int i_LeftVertexCount, i_RightVertexCount;
+                //int i_CurrentVertex;  //unused variable
 		bool cont=false;
 		vector<int> vi_forbiddenColors, vi_VerticesToBeColored, vi_verticesNeedNewColor;
 		i_LeftVertexCount = (int) m_vi_LeftVertices.size() - 1;
@@ -591,7 +595,7 @@ namespace ColPack
 			i_NumOfVerticesToBeColored = vi_verticesNeedNewColor.size();
 
 			vi_VerticesToBeColored.reserve(vi_verticesNeedNewColor.size());
-			for(int i=0; i<vi_verticesNeedNewColor.size(); i++) {
+			for(size_t i=0; i<vi_verticesNeedNewColor.size(); i++) {
 			  vi_VerticesToBeColored.push_back(vi_verticesNeedNewColor[i]);
 			}
 
@@ -738,7 +742,7 @@ namespace ColPack
 	int BipartiteGraphPartialColoring::GetLeftVertexColorCount()
 	{
 	  if(m_i_LeftVertexColorCount<0 && GetVertexColoringVariant() == "Row Partial Distance Two" ) {
-	    for(int i=0; i<m_vi_LeftVertexColors.size();i++) {
+	    for(size_t i=0; i<m_vi_LeftVertexColors.size();i++) {
 	      if(m_i_LeftVertexColorCount<m_vi_LeftVertexColors[i]) m_i_LeftVertexColorCount = m_vi_LeftVertexColors[i];
 	    }
 	  }
@@ -749,7 +753,7 @@ namespace ColPack
 	int BipartiteGraphPartialColoring::GetRightVertexColorCount()
 	{
 	  if(m_i_RightVertexColorCount<0 && GetVertexColoringVariant() == "Column Partial Distance Two" ) {
-	    for(int i=0; i<m_vi_RightVertexColors.size();i++) {
+	    for(size_t i=0; i<m_vi_RightVertexColors.size();i++) {
 	      if(m_i_RightVertexColorCount<m_vi_RightVertexColors[i]) m_i_RightVertexColorCount = m_vi_RightVertexColors[i];
 	    }
 	  }

--- a/BipartiteGraphPartialColoring/BipartiteGraphPartialOrdering.cpp
+++ b/BipartiteGraphPartialColoring/BipartiteGraphPartialOrdering.cpp
@@ -140,7 +140,7 @@ namespace ColPack
 		m_vi_OrderedVertices.clear();
 		m_vi_OrderedVertices.resize((unsigned) i_LeftVertexCount);
 
-		for(unsigned int i = 0; i<i_LeftVertexCount; i++) {
+		for(int i = 0; i<i_LeftVertexCount; i++) {
 			m_vi_OrderedVertices[i] = i;
 		}
 
@@ -163,7 +163,7 @@ namespace ColPack
 		m_vi_OrderedVertices.clear();
 		m_vi_OrderedVertices.resize((unsigned) i_RightVertexCount);
 
-		for(unsigned int i = 0; i<i_RightVertexCount; i++) {
+		for(int i = 0; i<i_RightVertexCount; i++) {
 			m_vi_OrderedVertices[i] = i + i_LeftVertexCount;
 		}
 
@@ -351,9 +351,9 @@ namespace ColPack
 
 // 		PrintBipartiteGraph();
 
-		int j, k, l, u;
+		//int j, k, l, u; //unused variable
 		int i_LeftVertexCount = (signed) m_vi_LeftVertices.size() - 1;
-		int i_RightVertexCount = (signed) m_vi_RightVertices.size() - 1;
+		//int i_RightVertexCount = (signed) m_vi_RightVertices.size() - 1;
 		vector<int> vi_Visited;
 		vi_Visited.clear();
 		vi_Visited.resize ( i_LeftVertexCount, _UNKNOWN );
@@ -462,7 +462,7 @@ namespace ColPack
 #endif
 		for(int k=0; k< i_MaxNumThreads; k++) {
 			//reset vi_Visited
-			for(int i=0; i< vi_Visited.size();i++) vi_Visited[i] = _UNKNOWN;
+			for(size_t i=0; i< vi_Visited.size();i++) vi_Visited[i] = _UNKNOWN;
 
 			//Line 7: while i_NumOfVerticesToBeColored >= 0 do // !!! ??? why not i_NumOfVerticesToBeColored > 0
 			while(i_NumOfVerticesToBeColored > 0) {
@@ -520,7 +520,7 @@ namespace ColPack
 // 							cout<<"*** i_w_location<0"<<endl<<flush;
 // 						}
 // 						cout<<"i_w_location after="<<i_w_location<<endl;
-						if(i_w_location != (B[ i_thread_num ][ d[w] ].size() - 1) ) B[ i_thread_num ] [ d[w] ][i_w_location] = B[ i_thread_num ] [ d[w] ][ B[ i_thread_num ][ d[w] ].size() - 1 ];
+						if(i_w_location != (((int)B[ i_thread_num ][ d[w] ].size()) - 1) ) B[ i_thread_num ] [ d[w] ][i_w_location] = B[ i_thread_num ] [ d[w] ][ B[ i_thread_num ][ d[w] ].size() - 1 ];
 						B[ i_thread_num ] [ d[w] ].pop_back();
 
 						//Line 14: d (w) <- d (w) - 1
@@ -751,7 +751,7 @@ namespace ColPack
 
 // 		PrintBipartiteGraph();
 
-		int j, k, l, u;
+		//int j, k, l, u; //unused variable
 		int i_LeftVertexCount = (signed) m_vi_LeftVertices.size() - 1;
 		int i_RightVertexCount = (signed) m_vi_RightVertices.size() - 1;
 		vector<int> vi_Visited;
@@ -862,7 +862,7 @@ namespace ColPack
 #endif
 		for(int k=0; k< i_MaxNumThreads; k++) {
 			//reset vi_Visited
-			for(int i=0; i< vi_Visited.size();i++) vi_Visited[i] = _UNKNOWN;
+			for(size_t i=0; i< vi_Visited.size();i++) vi_Visited[i] = _UNKNOWN;
 
 			//Line 7: while i_NumOfVerticesToBeColored >= 0 do // !!! ??? why not i_NumOfVerticesToBeColored > 0
 			while(i_NumOfVerticesToBeColored > 0) {
@@ -882,7 +882,7 @@ namespace ColPack
 // 				cout<<"delta[i_thread_num] 2="<< delta[i_thread_num] <<endl;
 
 				//Line 9: Let v be a vertex drawn from B_k [delta]
-				int v;
+				int v=0;
 
 				for(int i=delta[i_thread_num] ; i<i_MaxDegree_Private[i_thread_num]; i++) {
 					if(B[ i_thread_num ][ i ].size()!=0) {
@@ -920,7 +920,7 @@ namespace ColPack
 // 							cout<<"*** i_w_location<0"<<endl<<flush;
 // 						}
 // 						cout<<"i_w_location after="<<i_w_location<<endl;
-						if(i_w_location != (B[ i_thread_num ][ d[w] ].size() - 1) ) B[ i_thread_num ] [ d[w] ][i_w_location] = B[ i_thread_num ] [ d[w] ][ B[ i_thread_num ][ d[w] ].size() - 1 ];
+						if(i_w_location != (((signed)B[ i_thread_num ][ d[w] ].size()) - 1) ) B[ i_thread_num ] [ d[w] ][i_w_location] = B[ i_thread_num ] [ d[w] ][ B[ i_thread_num ][ d[w] ].size() - 1 ];
 						B[ i_thread_num ] [ d[w] ].pop_back();
 
 						//Line 14: d (w) <- d (w) - 1
@@ -1504,7 +1504,8 @@ namespace ColPack
 
 		int i, j, k, l, u;
 		int i_Current;
-		int i_HighestDegreeVertex, m_i_MaximumVertexDegree;
+		//int i_HighestDegreeVertex; //unused variable
+                int m_i_MaximumVertexDegree;
 		int i_VertexCount, i_VertexDegree, i_IncidenceVertexDegree;
 		int i_SelectedVertex, i_SelectedVertexCount;
 		vector<int> vi_IncidenceVertexDegree;
@@ -1517,7 +1518,7 @@ namespace ColPack
 		i_VertexCount = (int)m_vi_LeftVertices.size () - 1;
 		vvi_GroupedIncidenceVertexDegree.clear();
 		vvi_GroupedIncidenceVertexDegree.resize ( i_VertexCount );
-		i_HighestDegreeVertex = _UNKNOWN;
+		//i_HighestDegreeVertex = _UNKNOWN;//unused variable
 		m_i_MaximumVertexDegree = _UNKNOWN;
 		i_IncidenceVertexDegree = 0;
 		vi_Visited.resize ( i_VertexCount, _UNKNOWN );
@@ -1558,7 +1559,7 @@ namespace ColPack
 			if ( m_i_MaximumVertexDegree < i_VertexDegree )
 			{
 				m_i_MaximumVertexDegree = i_VertexDegree;
-				i_HighestDegreeVertex = i;
+				//i_HighestDegreeVertex = i; //unused variable
 			}
 		}
 
@@ -1666,7 +1667,8 @@ namespace ColPack
 
 		int i, j, k, l, u;
 		int i_Current;
-		int i_HighestDegreeVertex, m_i_MaximumVertexDegree;
+		//int i_HighestDegreeVertex; //unused variable
+                int m_i_MaximumVertexDegree;
 		int i_VertexCount, i_VertexDegree, i_IncidenceVertexDegree;
 		int i_SelectedVertex, i_SelectedVertexCount;
 		vector<int> vi_IncidenceVertexDegree;
@@ -1678,7 +1680,7 @@ namespace ColPack
 		i_SelectedVertex = _UNKNOWN;
 		i_VertexCount = (int)m_vi_RightVertices.size () - 1;
 		vvi_GroupedIncidenceVertexDegree.resize ( i_VertexCount );
-		i_HighestDegreeVertex = _UNKNOWN;
+		//i_HighestDegreeVertex = _UNKNOWN;//unused variable
 		m_i_MaximumVertexDegree = _UNKNOWN;
 		i_IncidenceVertexDegree = 0;
 		vi_Visited.resize ( i_VertexCount, _UNKNOWN );
@@ -1717,7 +1719,7 @@ namespace ColPack
 			if ( m_i_MaximumVertexDegree < i_VertexDegree )
 			{
 				m_i_MaximumVertexDegree = i_VertexDegree;
-				i_HighestDegreeVertex = i;
+				//i_HighestDegreeVertex = i;//unused variable
 			}
 		}
 

--- a/GraphColoring/GraphColoring.cpp
+++ b/GraphColoring/GraphColoring.cpp
@@ -19,7 +19,6 @@
 ************************************************************************************/
 
 #include "ColPackHeaders.h"
-
 using namespace std;
 
 namespace ColPack
@@ -97,13 +96,13 @@ namespace ColPack
 	{
 		int i;
 
-		int i_VertexCount;
+		//int i_VertexCount;
 
 		int i_ViolationCount;
 
 		i_ViolationCount = _FALSE;
 
-		i_VertexCount = STEP_DOWN((signed) m_vi_Vertices.size());
+		//i_VertexCount = STEP_DOWN((signed) m_vi_Vertices.size());
 
 		for(i=m_vi_Vertices[i_Vertex]; i<m_vi_Vertices[STEP_UP(i_Vertex)]; i++)
 		{
@@ -718,7 +717,7 @@ namespace ColPack
 				vector< pair<int, int> >* vpii_EdgesPtr = &(mpii_iter->second.value);
 				pair<int, int> pii_Edge;
 				// now start counting the appearance of vertices and detect conflict
-				for(int j=0; j< vpii_EdgesPtr->size(); j++  ) {
+				for(int j=0; j<(int) vpii_EdgesPtr->size(); j++  ) {
 					pii_Edge = (*vpii_EdgesPtr)[j];
 #ifdef COLPACK_DEBUG
 					cout<<"\t Looking at "<<pii_Edge.first<<"-"<<pii_Edge.second;
@@ -971,7 +970,7 @@ namespace ColPack
 						i_ConflictVertex[i_thread_num] = BuildStarFromColorCombination_forChecking(i_Mode, i_MaxNumThreads, i_thread_num, iter->first, Colors2Edge_Private, PotentialHub_Private);
 
 						if(i_ConflictVertex[i_thread_num]  != -1) {
-							#pragma omp critial
+							#pragma omp critical
 							{
 								if(pii_ConflictColorCombination!=NULL) {
 									(*pii_ConflictColorCombination).first = iter->first.first;
@@ -1017,7 +1016,7 @@ namespace ColPack
 	// !!! later on, remove the codes that check for conflicts (because we assume no conflict) => make this function run faster)
 	int GraphColoring::BuildStarFromColorCombination(int i_MaxNumThreads, int i_thread_num, pair<int, int> pii_ColorCombination, map< pair<int, int>, Colors2Edge_Value , lt_pii>* Colors2Edge_Private,
 							 map< int, vector< pair<int, int> > > *Vertex2ColorCombination_Private, map< int, int> * PotentialHub_Private) {
-		int i_VertexCount = m_vi_Vertices.size() - 1;
+		//int i_VertexCount = m_vi_Vertices.size() - 1;
 		map< pair<int, int>, Colors2Edge_Value, lt_pii >::iterator mpii_iter;
 		map< int, int>::iterator mii_iter;
 		int i_PotentialHub=0;
@@ -1036,7 +1035,7 @@ namespace ColPack
 				vector< pair<int, int> >* vpii_EdgesPtr = &(mpii_iter->second.value);
 				pair<int, int> pii_Edge;
 				// now start counting the appearance of vertices and detect conflict
-				for(int j=0; j< vpii_EdgesPtr->size(); j++  ) {
+				for(int j=0; j<(int) vpii_EdgesPtr->size(); j++  ) {
 					pii_Edge = (*vpii_EdgesPtr)[j];
 #ifdef COLPACK_DEBUG
 					cout<<"\t Looking at "<<pii_Edge.first<<"-"<<pii_Edge.second;
@@ -1140,7 +1139,7 @@ namespace ColPack
 	 */
 	int GraphColoring::DetectConflictInColorCombination(int i_MaxNumThreads, int i_thread_num, pair<int, int> pii_ColorCombination, map< pair<int, int>, Colors2Edge_Value , lt_pii>* Colors2Edge_Private,
 					     map< int, vector< pair<int, int> > > *Vertex2ColorCombination_Private, map< int, int> * PotentialHub_Private, vector< pair<int, int> >* ConflictedEdges_Private, vector<int>* ConflictCount_Private) {
-		int i_VertexCount = m_vi_Vertices.size() - 1;
+		//int i_VertexCount = m_vi_Vertices.size() - 1;
 		map< pair<int, int>, Colors2Edge_Value, lt_pii >::iterator mpii_iter;
 		map< int, int>::iterator mii_iter;
 		int i_PotentialHub=0;
@@ -1167,7 +1166,7 @@ namespace ColPack
 
 				pair<int, int> pii_Edge;
 				// now start counting the appearance of vertices and detect conflict
-				for(int j=0; j< vpii_EdgesPtr->size(); j++  ) {
+				for(int j=0; j<(int) vpii_EdgesPtr->size(); j++  ) {
 					pii_Edge = (*vpii_EdgesPtr)[j];
 					//#pragma omp critical
 					//{i_ProcessedEdgeCount++;}
@@ -1316,7 +1315,7 @@ namespace ColPack
 			if(itr != Colors2Edge_Private[i].end()) {
 				cout<<"(thread "<<i<<") ";
 				vector< pair<int, int> > *Edges = &(itr->second.value);
-				for(int ii=0; ii< (*Edges).size(); ii++) {
+				for(int ii=0; ii<(int) (*Edges).size(); ii++) {
 					cout<<(*Edges)[ii].first<<"-"<<(*Edges)[ii].second<<"; ";
 					i_ElementCount++;
 					if( i_ElementCount >= i_MaxElementsOfCombination) {
@@ -1347,7 +1346,7 @@ namespace ColPack
 						if(itr2 != Colors2Edge_Private[ii].end()) {
 							cout<<"(thread "<<ii<<") ";
 							vector< pair<int, int> > *Edges = &(itr2->second.value);
-							for(int iii=0; iii< (*Edges).size(); iii++) {
+							for(int iii=0; iii<(int) (*Edges).size(); iii++) {
 								cout<<(*Edges)[iii].first<<"-"<<(*Edges)[iii].second<<"; ";
 								i_ElementCount++;
 								if( i_ElementCount >= i_MaxElementsOfCombination) break;
@@ -1357,9 +1356,9 @@ namespace ColPack
 					}
 					cout<<endl;
 				}
-				if(mpiib_VisitedColorCombination.size() >= i_MaxNumOfCombination) break;
+				if( (int) mpiib_VisitedColorCombination.size() >= i_MaxNumOfCombination) break;
 			}
-			if(mpiib_VisitedColorCombination.size() >= i_MaxNumOfCombination) break;
+			if((int) mpiib_VisitedColorCombination.size() >= i_MaxNumOfCombination) break;
 		}
 		cout<<endl;
 
@@ -1385,7 +1384,7 @@ namespace ColPack
 				itr = Vertex2ColorCombination_Private[ii].find(i) ;
 				if(itr !=Vertex2ColorCombination_Private[ii].end()) {
 					cout<<"\t   Thread "<<ii<<" size()="<<itr->second.size()<<endl;
-					for(int iii=0; iii<itr->second.size();iii++) {
+					for(int iii=0; iii<(int) itr->second.size();iii++) {
 						cout<<"\t\t( Color "<<(itr->second)[iii].first<< ";";
 						if( (itr->second)[iii].second > -1) {
 							cout<<" NO hub, connect to "<<(itr->second)[iii].second;
@@ -1410,7 +1409,7 @@ namespace ColPack
 	int GraphColoring::PrintConflictEdges(vector< pair<int, int> > *ConflictedEdges_Private, int i_MaxNumThreads) {
 		cout<<"PrintConflictEdges"<<endl;
 		for(int i=0; i<i_MaxNumThreads;i++) {
-			for(int ii=0; ii<ConflictedEdges_Private[i].size();ii++) {
+			for(int ii=0; ii<(int)ConflictedEdges_Private[i].size();ii++) {
 				cout<<ConflictedEdges_Private[i][ii].first<<"-"<< ConflictedEdges_Private[i][ii].second <<endl;
 			}
 		}
@@ -1421,7 +1420,7 @@ namespace ColPack
 
 	int GraphColoring::PrintConflictCount(vector<int> &ConflictCount) {
 		cout<<"PrintConflictCount"<<endl;
-		for(int i=0; i<ConflictCount.size(); i++) {
+		for(int i=0; i<(int)ConflictCount.size(); i++) {
 			cout<<"Vertex "<<i<<": "<<ConflictCount[i]<<endl;
 		}
 		cout<<endl;
@@ -1437,7 +1436,7 @@ namespace ColPack
 		#pragma omp parallel for schedule(static,1) default(none) shared(cout, ConflictedEdges_Private, ConflictCount, i_MaxNumThreads)
 #endif
 		for(int i=0; i<i_MaxNumThreads; i++) {
-			for(int j=0; j< ConflictedEdges_Private[i].size(); j++) {
+			for(int j=0; j< (int)ConflictedEdges_Private[i].size(); j++) {
 				pair<int, int> pii_Edge = ConflictedEdges_Private[i][j];
 				//before decide which end, remember to check if one end's color is already removed. If this is the case, just skip to the next conflicted edge.
 				if(m_vi_VertexColors[pii_Edge.first] == _UNKNOWN || m_vi_VertexColors[pii_Edge.second] == _UNKNOWN ) continue;
@@ -1536,18 +1535,18 @@ namespace ColPack
 		#pragma omp parallel for default(none) shared(i_VertexCount, Vertex2ColorCombination_Private, Vertex2ColorCombination, i_MaxNumThreads)
 #endif
 		for(int i=0; i<i_VertexCount;i++) {
-			int i_thread_num;
+			//int i_thread_num;
 #ifdef _OPENMP
-			i_thread_num = omp_get_thread_num();
+			//i_thread_num = omp_get_thread_num();
 #else
-			i_thread_num = 0;
+			//i_thread_num = 0;
 #endif
 			map< int, vector< pair<int, int> > >::iterator iter;
 			for(int ii=0; ii<i_MaxNumThreads;ii++) {
 				iter = Vertex2ColorCombination_Private[ii].find(i);
 				if(iter != Vertex2ColorCombination_Private[ii].end()) {
 					vector< pair<int, int> >* vpii_Ptr = & (iter->second);
-					for(int iii=0; iii< vpii_Ptr->size(); iii++) {
+					for(int iii=0; iii< (int) vpii_Ptr->size(); iii++) {
 						(*Vertex2ColorCombination)[i][(*vpii_Ptr)[iii].first] = (*vpii_Ptr)[iii].second;
 					}
 
@@ -1686,7 +1685,7 @@ namespace ColPack
 			return _FALSE;
 		}
 		// Step *: now build a subgraph with my own structure
-		for(int i=0; i<m_vi_Vertices.size()-1;i++) {
+		for(int i=0; i<(int)m_vi_Vertices.size()-1;i++) {
 			if((*mib_Colors).find(m_vi_VertexColors[i]) == (*mib_Colors).end()) continue;
 
 			for(int ii=m_vi_Vertices[i]; ii<m_vi_Vertices[i+1];ii++) {
@@ -1749,7 +1748,7 @@ namespace ColPack
 
 		// Step *: now build a subgraph with my own structure
 		map<int,bool> mib_tmp;
-		for(int i=0; i<m_vi_Vertices.size()-1;i++) {
+		for(int i=0; i<(int)m_vi_Vertices.size()-1;i++) {
 			if(mib_IncludedVertices.find(i) == mib_IncludedVertices.end()) continue;
 			(*graph)[i] = mib_tmp; // just to make sure that my graphs will have all vertices (even when the vertex has no edge)
 			if(  mib_FilterByColors==NULL //NOT filter by colors
@@ -1827,7 +1826,7 @@ namespace ColPack
 
 		// Step *: now build a subgraph with my own structure
 		map<int,bool> mib_tmp;
-		for(int i=0; i<m_vi_Vertices.size()-1;i++) {
+		for(int i=0; i+1<(int)m_vi_Vertices.size();i++) {
 			if(mib_IncludedVertices.find(i) == mib_IncludedVertices.end()) continue;
 			(*graph)[i] = mib_tmp; // just to make sure that my graphs will have all vertices (even when the vertex has no edge)
 			for(int ii=m_vi_Vertices[i]; ii<m_vi_Vertices[i+1];ii++) {
@@ -1852,7 +1851,7 @@ namespace ColPack
 	int GraphColoring::PrintVertexAndColorAdded(int i_MaxNumThreads, vector< pair<int, int> > *vi_VertexAndColorAdded, int i_LastNEntries) {
 		int i_MaxSize = vi_VertexAndColorAdded[0].size();
 		for(int i=1; i<i_MaxNumThreads;i++) {
-			if(vi_VertexAndColorAdded[i].size()>i_MaxSize) i_MaxSize=vi_VertexAndColorAdded[i].size();
+			if(vi_VertexAndColorAdded[i].size()>(size_t)i_MaxSize) i_MaxSize=vi_VertexAndColorAdded[i].size();
 		}
 
 		if(i_LastNEntries>i_MaxSize) i_LastNEntries=i_MaxSize;
@@ -1991,7 +1990,7 @@ namespace ColPack
 		}
 		vi_VerticesToBeColored.resize(i_StartingIndex[i_MaxNumThreads-1]+vip_VerticesToBeRecolored_Private[i_MaxNumThreads-1].size(),_UNKNOWN);
 		for(int i=0 ; i< i_MaxNumThreads; i++) {
-			for(int j=0; j<vip_VerticesToBeRecolored_Private[i].size();j++) {
+			for(size_t j=0; j<vip_VerticesToBeRecolored_Private[i].size();j++) {
 				vi_VerticesToBeColored[i_StartingIndex[i]+j] = vip_VerticesToBeRecolored_Private[i][j];
 			}
 		}
@@ -2241,7 +2240,7 @@ namespace ColPack
 			cout<<"vi_VerticesToBeColored.size()="<<vi_VerticesToBeColored.size()<<endl;
 #endif
 			for(int i=0 ; i< i_MaxNumThreads; i++) {
-				for(int j=0; j<vip_VerticesToBeRecolored_Private[i].size();j++) {
+				for(int j=0; j<(int)vip_VerticesToBeRecolored_Private[i].size();j++) {
 					vi_VerticesToBeColored[i_StartingIndex[i]+j] = vip_VerticesToBeRecolored_Private[i][j];
 				}
 			}
@@ -2268,7 +2267,7 @@ namespace ColPack
 
 	int GraphColoring::PrintVertex2ColorCombination (vector<  map <int, int > > *Vertex2ColorCombination) {
 		cout<<"PrintVertex2ColorCombination()"<<endl;
-		for(int i=0; i< (*Vertex2ColorCombination).size(); i++) {
+		for(int i=0; i<(int) (*Vertex2ColorCombination).size(); i++) {
 			cout<<"v "<<i<<" c "<<m_vi_VertexColors[i]<<endl;
 			map<int, int>::iterator mii_iter = (*Vertex2ColorCombination)[i].begin();
 			for(; mii_iter != (*Vertex2ColorCombination)[i].end(); mii_iter++) {
@@ -2288,7 +2287,7 @@ namespace ColPack
 
 	int GraphColoring::PrintVertex2ColorCombination_raw (vector<  map <int, int > > *Vertex2ColorCombination) {
 		cout<<"PrintVertex2ColorCombination_raw()"<<endl;
-		for(int i=0; i< (*Vertex2ColorCombination).size(); i++) {
+		for(int i=0; i<(int) (*Vertex2ColorCombination).size(); i++) {
 			cout<<"v "<<i<<" c "<<m_vi_VertexColors[i]<<endl;
 			map<int, int>::iterator mii_iter = (*Vertex2ColorCombination)[i].begin();
 			for(; mii_iter != (*Vertex2ColorCombination)[i].end(); mii_iter++) {
@@ -2355,7 +2354,7 @@ namespace ColPack
 		//		in paper: A. Gebremedhin, A. Tarafdar, F. Manne and A. Pothen, New Acyclic and Star Coloring Algorithms with Applications to Hessian Computation, SIAM Journal on Scientific Computing, Vol 29, No 3, pp 1042--1072, 2007.
 		//  updating the collection of two-colored stars incident on the colored vertex v
 		// i.e. update vi_EdgeStarMap[][] and vi_StarHubMap[]
-		for(i=0; i<m_vi_Vertices.size()-1;i++) {
+		for(i=0; i<((int)m_vi_Vertices.size())-1;i++) {
 			if(m_vi_VertexColors[i] == _UNKNOWN) {
 				vi_VerticesToBeRecolored.push_back(i);
 				continue;
@@ -3207,7 +3206,7 @@ namespace ColPack
 	{
 		int i, j, k, l;
 
-		int i_VertexCount, i_EdgeCount;
+		int i_VertexCount /*, i_EdgeCount*/;
 
 		int i_FirstColor, i_SecondColor, i_ThirdColor, i_FourthColor;
 
@@ -3215,7 +3214,7 @@ namespace ColPack
 
 		i_VertexCount = STEP_DOWN((signed) m_vi_Vertices.size());
 
-		i_EdgeCount = (signed) m_vi_Edges.size();
+		/*i_EdgeCount = (signed) m_vi_Edges.size();*/
 
 		i_ViolationCount = _FALSE;
 
@@ -3312,7 +3311,7 @@ namespace ColPack
 		cout<<"Note: 1-based indexing is used"<<endl;
 		int i, j, k, l;
 
-		int i_VertexCount, i_EdgeCount;
+		int i_VertexCount /*, i_EdgeCount */;
 
 		int i_FirstColor, i_SecondColor, i_ThirdColor, i_FourthColor;
 
@@ -3320,7 +3319,7 @@ namespace ColPack
 
 		i_VertexCount = STEP_DOWN((signed) m_vi_Vertices.size());
 
-		i_EdgeCount = (signed) m_vi_Edges.size();
+		//i_EdgeCount = (signed) m_vi_Edges.size();
 
 		i_ViolationCount = _FALSE;
 

--- a/GraphColoring/GraphInputOutput.cpp
+++ b/GraphColoring/GraphInputOutput.cpp
@@ -182,7 +182,7 @@ namespace ColPack
 		//initialize local data
 		int col=0, row=0, rowIndex=0, colIndex=0;
 		int entry_counter = 0, num_of_entries = 0;
-		bool value_not_specified = false;
+		//bool value_not_specified = false; //unused variable
 		//int num=0, numCount=0;
 		double value;
 		bool b_getValue = !b_getStructureOnly, b_symmetric;
@@ -377,7 +377,8 @@ namespace ColPack
 		{
 			cout<<"Found File "<<m_s_InputFile<<endl;
 		}
-		int i_Dummy, i, j;
+		//int i_Dummy; //unused variable
+                int i, j;
 		int num, counter;
 		double d;
 		int nnz;
@@ -524,7 +525,7 @@ namespace ColPack
 		//populate the m_vi_Vertices, their Edges and Values at the same time
 		m_vi_Vertices[0]=0;
 		for(i=0; i<NROW; i++) {
-		  for(j=0; j<vvi_VertexAdjacency[i].size();j++) {
+		  for(j=0;(size_t)j<vvi_VertexAdjacency[i].size();j++) {
 		    m_vi_Edges[m_vi_Vertices[i]+j] = vvi_VertexAdjacency[i][j];
 		    if(VALCRD !=0) m_vd_Values[m_vi_Vertices[i]+j] = vvd_Values[i][j];
 		  }
@@ -793,7 +794,7 @@ namespace ColPack
 
 		int i_VertexCount, i_VertexDegree;
 
-		int i_EdgeCount;
+		//int i_EdgeCount; //unused variable
 
 		int i_VertexWeights, i_EdgeWeights;
 
@@ -857,7 +858,7 @@ namespace ColPack
 				}
 
 				i_VertexCount = atoi(vs_InputTokens[0].c_str());
-				i_EdgeCount = atoi(vs_InputTokens[1].c_str());
+				//i_EdgeCount = atoi(vs_InputTokens[1].c_str()); //unused variable
 
 				i_VertexWeights = _FALSE;
 				i_EdgeWeights = _FALSE;
@@ -1146,7 +1147,8 @@ namespace ColPack
 	{
 		int i;
 
-		int i_VertexCount, i_EdgeCount;
+		int i_VertexCount;
+                //int i_EdgeCount; //unused variable
 
 		i_VertexCount = (signed) m_vi_Vertices.size();
 

--- a/GraphColoring/GraphOrdering.cpp
+++ b/GraphColoring/GraphOrdering.cpp
@@ -182,8 +182,6 @@ namespace ColPack
 
 		m_s_VertexOrderingVariant = "RANDOM";
 
-		int i;
-
 		int i_VertexCount;
 
 		i_VertexCount = STEP_DOWN((signed) m_vi_Vertices.size());
@@ -193,7 +191,7 @@ namespace ColPack
 		m_vi_OrderedVertices.resize((unsigned) i_VertexCount);
 
 		//initialize m_vi_OrderedVertices
-		for(unsigned int i = 0; i<i_VertexCount; i++) {
+		for(int i = 0; i<i_VertexCount; i++) {
 			m_vi_OrderedVertices[i] = i;
 		}
 
@@ -247,7 +245,7 @@ namespace ColPack
 		int i_HighestColor = _FALSE;
 
 		//Populate ColorGroups
-		for(int i=0; i < vi_VertexColors.size(); i++)
+		for(int i=0; i <(int)vi_VertexColors.size(); i++)
 		{
 			vvi_ColorGroups[vi_VertexColors[i]].push_back(i);
 
@@ -341,14 +339,14 @@ namespace ColPack
 		string tempS;
 		cout<<"vvpii_VertexEdgeMap.size() = "<<vvpii_VertexEdgeMap.size()<<endl;
 
-		for(int i=0; i<vvpii_VertexEdgeMap.size(); i++) {
+		for(int i=0; i<(int)vvpii_VertexEdgeMap.size(); i++) {
 			cout<<'['<<setw(4)<<i<<']';
-			for(int j=0; j< vvpii_VertexEdgeMap[i].size(); j++) {
+			for(int j=0; j<(int)vvpii_VertexEdgeMap[i].size(); j++) {
 				oout.str("");
 				oout << '(' << vvpii_VertexEdgeMap[i][j].first << ", " << vvpii_VertexEdgeMap[i][j].second << ')';
 				tempS = oout.str();
 				cout<<setw(10)<<tempS;
-				if(j%5 == 4 && j != vvpii_VertexEdgeMap[i].size() - 1) cout<<endl<<setw(6)<<' ';
+				if(j%5 == 4 && j !=((int)vvpii_VertexEdgeMap[i].size()) - 1) cout<<endl<<setw(6)<<' ';
 			}
 			cout<<endl;
 		}
@@ -1630,7 +1628,7 @@ namespace ColPack
 			currentOrderingID = vectorID2orderingID[i];
 			i_CurrentVertexBackDegre = 0;
 			//for through all the D1 neighbor of that vertex
-			for( unsigned int j = m_vi_Vertices[i]; j < m_vi_Vertices[i + 1]; j++) {
+			for( unsigned int j = m_vi_Vertices[i]; j <(unsigned int) m_vi_Vertices[i + 1]; j++) {
 				if(vectorID2orderingID[m_vi_Edges[j]] < currentOrderingID) i_CurrentVertexBackDegre++;
 			}
 			if( i_MaxBackDegree < i_CurrentVertexBackDegre) i_MaxBackDegree = i_CurrentVertexBackDegre;

--- a/Utilities/extra.cpp
+++ b/Utilities/extra.cpp
@@ -65,7 +65,7 @@ int WriteMatrixMarket_ADOLCInput(string s_postfix, int i_mode, ...) {
 
     out_Matrix<<setprecision(10)<<scientific<<showpoint;
     for(int i = 0; i<i_Matrix_Row;i++) {
-      for(int j = 1; j<=uip2_SparsityPattern[i][0];j++) {
+      for(unsigned int j = 1; j<=uip2_SparsityPattern[i][0];j++) {
 	out_Matrix<<i+1<<" "<<uip2_SparsityPattern[i][j]+1;
 	out_Matrix<<endl;
       }
@@ -100,7 +100,7 @@ int WriteMatrixMarket_ADOLCInput(string s_postfix, int i_mode, ...) {
 
     out_Matrix<<setprecision(10)<<scientific<<showpoint;
     for(int i = 0; i<i_Matrix_Row;i++) {
-      for(int j = 1; j<=uip2_SparsityPattern[i][0];j++) {
+      for(unsigned int j = 1; j<=uip2_SparsityPattern[i][0];j++) {
 	out_Matrix<<i+1<<" "<<uip2_SparsityPattern[i][j]+1;
 	out_Matrix<<endl;
       }
@@ -156,7 +156,7 @@ int WriteMatrixMarket_ADOLCInput(string s_postfix, int i_mode, ...) {
 
     out_Matrix<<setprecision(10)<<scientific<<showpoint;
     for(int i = 0; i<i_Matrix_Row;i++) {
-      for(int j = 1; j<=uip2_SparsityPattern[i][0];j++) {
+      for(unsigned int j = 1; j<=uip2_SparsityPattern[i][0];j++) {
 	out_Matrix<<i+1<<" "<<uip2_SparsityPattern[i][j]+1<<" "<<dp2_Values[i][j];
 	out_Matrix<<endl;
       }
@@ -651,8 +651,8 @@ int buildDotWithColor(ColPack::GraphColoringInterface &g, vector<string> &ListOf
   vector<bool> m_vi_ConflictEdges;
   m_vi_ConflictEdges.resize(m_vi_Edges.size(),false);
   if(ListOfConflicts.size()>0) {
-    for(int i=0; i<ListOfConflicts.size();i++) {
-      for(int j=0; j<ListOfConflicts[i].size()-1;j++) {
+    for(size_t i=0; i<ListOfConflicts.size();i++) {
+      for(int j=0; j< ((int)ListOfConflicts[i].size())-1;j++) {
 	int Vertex1 = ListOfConflicts[i][j];
 	int Vertex2 = ListOfConflicts[i][j+1];
 	if(Vertex1 > Vertex2) { //swap order
@@ -717,9 +717,9 @@ bool isValidOrdering(vector<int> & ordering, int offset) {
   int orderingNum = 0;
   isExist.resize(ordering.size(), false);
   index.resize(ordering.size(), false);
-  for(int i=0; i<ordering.size(); i++) {
+  for(int i=0; i<(int)ordering.size(); i++) {
     orderingNum = ordering[i] - offset;
-    if(orderingNum<0 || orderingNum>= ordering.size()) {
+    if(orderingNum<0 || (unsigned int)orderingNum>= ordering.size()) {
       cerr<<" This vertex # is not in the valid range [0, ordering.size()]. ordering[i]: "<<ordering[i]<<endl;
       return false;
     }
@@ -858,7 +858,7 @@ int ConvertCoordinateFormat2RowCompressedFormat(unsigned int* uip1_RowIndex, uns
   //Populate values of (*dp3_Pattern) and (*dp3_Values)
   count=0;
   for(int i=0; i<i_RowCount; i++) {
-    for(int j=1; j<= (*dp3_Pattern)[i][0]; j++) {
+    for(unsigned int j=1; j<= (*dp3_Pattern)[i][0]; j++) {
       (*dp3_Pattern)[i][j] = uip1_ColumnIndex[count];
       (*dp3_Values)[i][j] = dp1_HessianValue[count];
       count++;
@@ -1001,7 +1001,7 @@ int ConvertRowCompressedFormat2ADIC(unsigned int ** uip2_SparsityPattern_RowComp
     std::set<int> valset;
     std::vector<double> valuevector;
     valuevector.reserve(uip2_SparsityPattern_RowCompressedFormat[i][0]);
-    for(int j= 1; j <= uip2_SparsityPattern_RowCompressedFormat[i][0]; j++) {
+    for(unsigned int j= 1; j <= uip2_SparsityPattern_RowCompressedFormat[i][0]; j++) {
       valset.insert(uip2_SparsityPattern_RowCompressedFormat[i][j]);
       valuevector.push_back(dp2_Value[i][j]);
     }
@@ -1028,7 +1028,7 @@ int ConvertRowCompressedFormat2CSR(unsigned int ** uip2_SparsityPattern_RowCompr
   (*ip_ColumnIndex) = new int[nnz];
   int nz_count=0;
   for(int i=0; i < i_rowCount; i++) {
-    for(int j=1; j<= uip2_SparsityPattern_RowCompressedFormat[i][0];j++) {
+    for(unsigned int j=1; j<= uip2_SparsityPattern_RowCompressedFormat[i][0];j++) {
       (*ip_ColumnIndex)[nz_count] = uip2_SparsityPattern_RowCompressedFormat[i][j];
       nz_count++;
     }
@@ -1047,7 +1047,9 @@ int ConvertMatrixMarketFormat2RowCompressedFormat(string s_InputFile, unsigned i
 	string m_s_InputFile=s_InputFile;
 
 	//initialize local data
-	int rowCounter=0, nonzeros=0, rowIndex=0, colIndex=0, nz_counter=0, entries=0;
+	int rowCounter=0, rowIndex=0, colIndex=0, nz_counter=0, entries=0;
+        //int nonzeros=0; //unused variable
+
 	//int num=0, numCount=0;
 	float value;
 	bool b_getValue, b_symmetric;
@@ -1429,7 +1431,7 @@ bool CompressedRowMatricesAreEqual(double** dp3_Value, double** dp3_NewValue, in
 }
 
 int DisplayADICFormat_Sparsity(std::list<std::set<int> > &lsi_valsetlist) {
-	int size = (lsi_valsetlist).size();
+	//int size = (lsi_valsetlist).size(); //unused variable
 	int rowIndex=-1, colIndex=-1;
 	std::list<std::set<int> >::iterator valsetlistiter = (lsi_valsetlist).begin();
 
@@ -1455,7 +1457,7 @@ int DisplayADICFormat_Sparsity(std::list<std::set<int> > &lsi_valsetlist) {
 }
 
 int DisplayADICFormat_Value(std::list<std::vector<double> > &lvd_Value) {
-	int size = (lvd_Value).size();
+	//int size = (lvd_Value).size(); //unused variable
 	int rowIndex=-1;
 	double value=0.;
 	std::list<std::vector<double> >::iterator valsetlistiter = (lvd_Value).begin();

--- a/Utilities/mmio.cpp
+++ b/Utilities/mmio.cpp
@@ -461,13 +461,13 @@ char  *mm_typecode_to_str(MM_typecode matcode)
     char buffer[MM_MAX_LINE_LENGTH];
     const char *types[4];
 	char *mm_strdup(const char *);
-    int error =0;
+    //int error =0; //unused variable
 
     /* check for MTX type */
     if (mm_is_matrix(matcode))
         types[0] = MM_MTX_STR;
-    else
-        error=1;
+    //else             //unused variable
+    //    error=1;     //unused variable
 
     /* check for CRD or ARR matrix */
     if (mm_is_sparse(matcode))

--- a/Utilities/stat.cpp
+++ b/Utilities/stat.cpp
@@ -248,7 +248,7 @@ void toFileC(string baseDir, string stat_output_suffix, vector<string> Orderings
 	// Create titles
 	if(stat_flags["NumberOfColors"]) {
 	  out_NumberOfColors<<"Style, Name";
-	  for(int i=0; i< Orderings.size(); i++) {
+	  for(size_t i=0; i< Orderings.size(); i++) {
 	    out_NumberOfColors<<", "<<Orderings[i];
 	  }
 	  out_NumberOfColors<<endl;
@@ -257,14 +257,14 @@ void toFileC(string baseDir, string stat_output_suffix, vector<string> Orderings
 	if(stat_flags["Time"]) {
 	  // line 1
 	  out_Time<<"Style,Name";
-	  for(int i=0; i< Orderings.size(); i++) {
+	  for(size_t i=0; i< Orderings.size(); i++) {
 	    out_Time<<", "<<Orderings[i]<<", , ";
 	  }
 	  out_Time<<endl;
 
 	  // line 2
 	  out_Time<<",";
-	  for(int i=0; i< Orderings.size(); i++) {
+	  for(size_t i=0; i< Orderings.size(); i++) {
 	    out_Time<<", OT, CT, TT";
 	  }
 	  out_Time<<endl;
@@ -272,7 +272,7 @@ void toFileC(string baseDir, string stat_output_suffix, vector<string> Orderings
 
 	if(stat_flags["MaxBackDegree"]) {
 	  out_MaxBackDegree<<"Name";
-	  for(int i=0; i< Orderings.size(); i++) {
+	  for(size_t i=0; i< Orderings.size(); i++) {
 	    out_MaxBackDegree<<", "<<Orderings[i];
 	  }
 	  out_MaxBackDegree<<endl;
@@ -285,7 +285,7 @@ void toFileC(string baseDir, string stat_output_suffix, vector<string> Orderings
 	for(unsigned int i=0;i < listOfGraphs.size(); i++){
 		printListOfGraphs(listOfGraphs,i);
 
-		for(int j=0;j < Colorings.size();j++) {
+		for(size_t j=0;j < Colorings.size();j++) {
 			cout<<Colorings[j]<<" Coloring"<<endl<<flush;
 			if(stat_flags["NumberOfColors"]) out_NumberOfColors<<Colorings[j]<<", ";
 			if(stat_flags["Time"]) out_Time<<Colorings[j]<<", ";
@@ -296,7 +296,7 @@ void toFileC(string baseDir, string stat_output_suffix, vector<string> Orderings
 			if(stat_flags["Time"]) out_Time<<stat_file_parsor.GetName();
 			if(stat_flags["MaxBackDegree"] && j == 0) out_MaxBackDegree<<stat_file_parsor.GetName();
 
-			for(int k=0;k < Orderings.size();k++) {
+			for(size_t k=0;k < Orderings.size();k++) {
 				current_time();
 
 				cout<<Orderings[k]<<" Ordering"<<endl<<flush;
@@ -477,7 +477,7 @@ void toFileStatisticForBipartiteGraph(string baseDir, string stat_output_suffix,
 }
 
 void printListOfGraphs(vector <string>& listOfGraphs, int selected) {
-	for(int i=0; i<listOfGraphs.size();i++) {
+	for(int i=0; i<(int)listOfGraphs.size();i++) {
 		if(i!=selected) cout<<"  Graph: "<<listOfGraphs[i]<<endl;
 		else cout<<"=>Graph: "<<listOfGraphs[i]<<endl;
 	}
@@ -519,14 +519,14 @@ void toFileBiC(string baseDir, string stat_output_suffix , vector<string> Orderi
 	// Create titles
 	if(stat_flags["NumberOfColors"]) {
 	  out_NumberOfColors<<"Style, Name";
-	  for(int i=0; i< Orderings.size(); i++) {
+	  for(size_t i=0; i< Orderings.size(); i++) {
 	    out_NumberOfColors<<", "<<Orderings[i]<<", , ";
 	  }
 	  out_NumberOfColors<<endl;
 
 	  // line 2
 	  out_NumberOfColors<<",";
-	  for(int i=0; i< Orderings.size(); i++) {
+	  for(size_t i=0; i< Orderings.size(); i++) {
 	    out_NumberOfColors<<", LEFT, RIGHT, TOTAL";
 	  }
 	  out_NumberOfColors<<endl;
@@ -535,14 +535,14 @@ void toFileBiC(string baseDir, string stat_output_suffix , vector<string> Orderi
 	if(stat_flags["Time"]) {
 	  // line 1
 	  out_Time<<"Style,Name";
-	  for(int i=0; i< Orderings.size(); i++) {
+	  for(size_t i=0; i< Orderings.size(); i++) {
 	    out_Time<<", "<<Orderings[i]<<", , ";
 	  }
 	  out_Time<<endl;
 
 	  // line 2
 	  out_Time<<",";
-	  for(int i=0; i< Orderings.size(); i++) {
+	  for(size_t i=0; i< Orderings.size(); i++) {
 	    out_Time<<", OT, CT, TT";
 	  }
 	  out_Time<<endl;
@@ -551,7 +551,7 @@ void toFileBiC(string baseDir, string stat_output_suffix , vector<string> Orderi
     for(unsigned int i=0;i < listOfGraphs.size(); i++){
 		printListOfGraphs(listOfGraphs,i);
 
-		for(int j=0;j<Colorings.size();j++)
+		for(size_t j=0;j<Colorings.size();j++)
 		{
 			cout<<Colorings[j]<<" Coloring"<<endl<<flush;
 			if(stat_flags["NumberOfColors"]) out_NumberOfColors<<Colorings[j]<<", ";
@@ -562,7 +562,7 @@ void toFileBiC(string baseDir, string stat_output_suffix , vector<string> Orderi
 			if(stat_flags["NumberOfColors"]) out_NumberOfColors<<stat_file_parsor.GetName();
 			if(stat_flags["Time"]) out_Time<<stat_file_parsor.GetName();
 
-			for (int k=0; k<Orderings.size(); k++)
+			for (size_t k=0; k<Orderings.size(); k++)
 			{
 				current_time();
 
@@ -633,7 +633,7 @@ void toFileBiPC(string baseDir, string stat_output_suffix, vector<string> Orderi
 	// Create titles
 	if(stat_flags["NumberOfColors"]) {
 	  out_NumberOfColors<<"Style, Name";
-	  for(int i=0; i< Orderings.size(); i++) {
+	  for(unsigned int i=0; i< Orderings.size(); i++) {
 	    out_NumberOfColors<<", "<<Orderings[i];
 	  }
 	  out_NumberOfColors<<endl;
@@ -642,14 +642,14 @@ void toFileBiPC(string baseDir, string stat_output_suffix, vector<string> Orderi
 	if(stat_flags["Time"]) {
 	  // line 1
 	  out_Time<<"Style,Name";
-	  for(int i=0; i< Orderings.size(); i++) {
+	  for(unsigned int i=0; i< Orderings.size(); i++) {
 	    out_Time<<", "<<Orderings[i]<<", , ";
 	  }
 	  out_Time<<endl;
 
 	  // line 2
 	  out_Time<<",";
-	  for(int i=0; i< Orderings.size(); i++) {
+	  for(unsigned int i=0; i< Orderings.size(); i++) {
 	    out_Time<<", OT, CT, TT";
 	  }
 	  out_Time<<endl;
@@ -658,7 +658,7 @@ void toFileBiPC(string baseDir, string stat_output_suffix, vector<string> Orderi
     for(unsigned int i=0;i < listOfGraphs.size(); i++){
 		printListOfGraphs(listOfGraphs,i);
 
-		for(int j=0;j<Colorings.size();j++)
+		for(unsigned int j=0;j<Colorings.size();j++)
 		{
 			cout<<Colorings[j]<<" Coloring"<<endl<<flush;
 			if(stat_flags["NumberOfColors"]) out_NumberOfColors<<Colorings[j]<<", ";
@@ -669,7 +669,7 @@ void toFileBiPC(string baseDir, string stat_output_suffix, vector<string> Orderi
 			if(stat_flags["NumberOfColors"]) out_NumberOfColors<<stat_file_parsor.GetName();
 			if(stat_flags["Time"]) out_Time<<stat_file_parsor.GetName();
 
-			for (int k=0; k<Orderings.size(); k++)	{
+			for (unsigned int k=0; k<Orderings.size(); k++)	{
 				current_time();
 
 				cout<<Orderings[k]<<" Ordering"<<endl<<flush;


### PR DESCRIPTION
Most of the warnings are caused by _comparison between signed and unsigned integer expressions_. => changed to _signed_ or _unsigned_  accordingly.
Some of the warnings are caused by _unused variables_. => commented those variables.