### PR TITLE
Fix install

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -75,7 +75,7 @@ if(WIN32)
     set(COLPACK_INSTALL_CMAKEDIR       ColPack_libs)
     set(COLPACK_INSTALL_EXAMPLESBINDIR ColPack_examples)
 else()
-    set(COLPACK_INSTALL_CMAKEDIR       "lib/cmake/ColPack")
+    set(COLPACK_INSTALL_CMAKEDIR       "${CMAKE_INSTALL_LIBDIR}/cmake/ColPack")
     # To follow the UNIX Filsystem Hierarchy Standard, we should install
     # examples somewhere else:
     set(COLPACK_INSTALL_EXAMPLESBINDIR ${CMAKE_INSTALL_LIBDIR}/ColPack_examples)
@@ -132,7 +132,7 @@ target_include_directories(ColPack_static PRIVATE
 #    "$<BUILD_INTERFACE:${COLPACK_SOURCE_INCLUDE_DIRS}>")
 # For clients of an installation of ColPack.
 target_include_directories(ColPack_static INTERFACE
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ColPack>)
 
 if(ENABLE_OPENMP)
     set_target_properties(ColPack_static PROPERTIES COMPILE_FLAGS
@@ -141,7 +141,8 @@ endif()
 
 # "EXPORT" helps with creating a ColPackConfig.cmake file to place in the
 # installation, to help downstream projects use ColPack.
-install(TARGETS ColPack_static EXPORT ColPackTargets)
+install(TARGETS ColPack_static EXPORT ColPackTargets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 
 # Shared library.
@@ -159,7 +160,7 @@ target_include_directories(ColPack_shared PRIVATE
 #    "$<BUILD_INTERFACE:${COLPACK_SOURCE_INCLUDE_DIRS}>")
 # For clients of an installation of ColPack.
 target_include_directories(ColPack_shared INTERFACE
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ColPack>)
 
 if(ENABLE_OPENMP)
     set_target_properties(ColPack_shared PROPERTIES COMPILE_FLAGS
@@ -248,23 +249,30 @@ endforeach()
 
 # Create files that define the ColPack targets to import into other projects.
 # https://cmake.org/cmake/help/v3.1/manual/cmake-packages.7.html
-install(EXPORT ColPackTargets DESTINATION ${COLPACK_INSTALL_CMAKEDIR})
+
+install(EXPORT ColPackTargets
+  DESTINATION ${COLPACK_INSTALL_CMAKEDIR}
+  NAMESPACE "ColPack::")
 
 # CMake Config file., and version file, which CMake will look for when
 # downstream projects use find_package(ColPack).
 include(CMakePackageConfigHelpers)
 # The ConfigVersion file determines if an installed copy of ColPack is
 # compatible with a user's requested version for ColPack.
+
 write_basic_package_version_file(
     "${CMAKE_BINARY_DIR}/ColPackConfigVersion.cmake"
     VERSION ${COLPACK_VERSION}
     COMPATIBILITY AnyNewerVersion)
+
 configure_package_config_file(ColPackConfig.cmake.in
     "${CMAKE_BINARY_DIR}/ColPackConfigToInstall.cmake"
     INSTALL_DESTINATION ${COLPACK_INSTALL_CMAKEDIR}
     PATH_VARS CMAKE_INSTALL_PREFIX)
+
 install(FILES "${CMAKE_BINARY_DIR}/ColPackConfigToInstall.cmake"
     DESTINATION ${COLPACK_INSTALL_CMAKEDIR}
     RENAME ColPackConfig.cmake)
+
 install(FILES "${CMAKE_BINARY_DIR}/ColPackConfigVersion.cmake"
     DESTINATION ${COLPACK_INSTALL_CMAKEDIR})

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -69,13 +69,13 @@ if(ENABLE_OPENMP)
 endif()
 
 # Define variables to use for organizing the installation.
-include(GNUInstallDirs) 
+include(GNUInstallDirs)
 
 if(WIN32)
     set(COLPACK_INSTALL_CMAKEDIR       ColPack_libs)
     set(COLPACK_INSTALL_EXAMPLESBINDIR ColPack_examples)
 else()
-    set(COLPACK_INSTALL_CMAKEDIR       ${CMAKE_INSTALL_LIBDIR}/ColPack_libs)
+    set(COLPACK_INSTALL_CMAKEDIR       "lib/cmake/ColPack")
     # To follow the UNIX Filsystem Hierarchy Standard, we should install
     # examples somewhere else:
     set(COLPACK_INSTALL_EXAMPLESBINDIR ${CMAKE_INSTALL_LIBDIR}/ColPack_examples)
@@ -141,10 +141,7 @@ endif()
 
 # "EXPORT" helps with creating a ColPackConfig.cmake file to place in the
 # installation, to help downstream projects use ColPack.
-install(TARGETS ColPack_static EXPORT ColPackTargets
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/archive
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/library
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/runtime)
+install(TARGETS ColPack_static EXPORT ColPackTargets)
 
 
 # Shared library.
@@ -170,12 +167,9 @@ if(ENABLE_OPENMP)
     target_link_libraries(ColPack_shared PRIVATE ${OpenMP_CXX_FLAGS})
 endif()
 
-install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ColPack_headers)
+install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ColPack)
 
-install(TARGETS ColPack_shared EXPORT ColPackTargets
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/shared_archive
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/shared_library
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/shared_runtime)
+install(TARGETS ColPack_shared EXPORT ColPackTargets)
 
 
 


### PR DESCRIPTION
As was pointed out in #29, the install directories are not set in a fashion consistent with well-established standards:

- Libraries should go into <prefix>/lib and not in <prefix>/lib/ColPack_static
- Cmake configurations must go into <prefix>/lib/cmake/ColPack in order
  for cmake to be able to find them.
- Exported targes should be namespace'd

Also, the includes for the installed files 
https://github.com/CSCsw/ColPack/blob/master/build/cmake/CMakeLists.txt#L134-L135
and the location of the installed includes
https://github.com/CSCsw/ColPack/blob/master/build/cmake/CMakeLists.txt#L173
must coincide. Otherwise exporting targets becomes rather pointless.

This request contains fixes to all of these issues. As a result, a simple example project of the form

    find_package(ColPack REQUIRED)
    target_link_libraries(<example app> ColPack::ColPack_shared)

actually compiles :)