### PR TITLE
NULL->string() to eliminate UB, support MSVC 2022

### DIFF
--- a/src/Utilities/StringTokenizer.cpp
+++ b/src/Utilities/StringTokenizer.cpp
@@ -221,7 +221,7 @@ namespace ColPack
 
 	  if (TokenStringLength == 0)
 	  {
-		return(NULL);
+		return string();
 	  }
 
 	  if (DelimiterStringLength == 0)


### PR DESCRIPTION
Per https://www.cplusplus.com/reference/string/string/string: "If s is a null pointer ... it causes undefined behavior."

This article by C++ Standards Committee member Aaron Ballman reinforces that: https://wiki.sei.cmu.edu/confluence/display/cplusplus/STR51-CPP.+Do+not+attempt+to+create+a+std%3A%3Astring+from+a+null+pointer

The MSVC 2022 Preview release, with /std:c++latest, flags this lines as an error.