### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -98,7 +98,7 @@ file(GLOB SOURCES
     ${COLPACK_ROOT_DIR}/src/BipartiteGraphBicoloring/*.cpp
     ${COLPACK_ROOT_DIR}/src/BipartiteGraphPartialColoring/*.cpp
     ${COLPACK_ROOT_DIR}/src/GeneralGraphColoring/*.cpp
-    ${COLPACK_ROOT_DIR}/src/Recovery/*.h
+    ${COLPACK_ROOT_DIR}/src/Recovery/*.cpp
     ${COLPACK_ROOT_DIR}/src/SMPGC/*.cpp)
     #${COLPACK_ROOT_DIR}/src/PartialD2SMPGC/*.cpp)
 


### PR DESCRIPTION
The Recovery functions were not built because of the wrong extension (.h instead of .cpp)