### PR TITLE
Fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Install ColPack makes ColPack easy to use and it can also decreases the size of 
     git clone https://github.com/CSCsw/ColPack.git  #Download ColPack
     cd ColPack             # ColPack Root Directory
     cd build/automake      # automake folder
-    autoreconf -vif        # generate configure files based on the machince
+    autoreconf -vif        # generate configure files based on the machine
     mkdir mywork           
     cd mywork
     fullpath=$(pwd)        # modify fullpath to your destination folder if need


### PR DESCRIPTION
Fixed a typo on "Ubuntu Build and Install ColPack Instruction" script comments: "machince" -> "machine"